### PR TITLE
Fixed & Tested: Udp-Throughput and TCP-Throughput finalized

### DIFF
--- a/control-plane/control-plane.go
+++ b/control-plane/control-plane.go
@@ -2,9 +2,9 @@ package controlPlane
 
 import "fmt"
 import "os"
-import "github.com/monfron/mapago/control-plane/ctrl/server-protocols"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
-import "github.com/monfron/mapago/management-plane"
+import "github.com/protocollabs/mapago/control-plane/ctrl/server-protocols"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/management-plane"
 
 var CTRL_PORT = 64321
 var DEF_BUFFER_SIZE = 8096 * 8

--- a/control-plane/ctrl/client-protocols/tcp.go
+++ b/control-plane/ctrl/client-protocols/tcp.go
@@ -4,7 +4,7 @@ import "fmt"
 import "net"
 import "strconv"
 import "os"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
 // classes
 

--- a/control-plane/ctrl/client-protocols/tcp.go
+++ b/control-plane/ctrl/client-protocols/tcp.go
@@ -119,7 +119,7 @@ func (tcp *TcpObj) StartMeasurement(jsonData []byte) *shared.DataObj {
 		repDataObj = shared.ConvJsonToDataStruct(buf[:bytes])
 
 		if repDataObj.Type == shared.MEASUREMENT_START_REPLY {
-			fmt.Printf("\nClient received an TCP Measurement_Start_Reply!!!")
+			fmt.Printf("\nClient received an Measurement_Start_Reply!!!")
 			break
 		}
 	}
@@ -166,7 +166,7 @@ func (tcp *TcpObj) StopMeasurement(jsonData []byte) *shared.DataObj {
 		repDataObj = shared.ConvJsonToDataStruct(buf[:bytes])
 
 		if repDataObj.Type == shared.MEASUREMENT_STOP_REPLY {
-			fmt.Printf("\nClient received an TCP Measurement_Stop_Reply!!!")
+			fmt.Printf("\nClient received an Measurement_Stop_Reply!!!")
 			break
 		}
 	}
@@ -213,7 +213,7 @@ func (tcp *TcpObj) GetMeasurementInfo(jsonData []byte) *shared.DataObj {
 		repDataObj = shared.ConvJsonToDataStruct(buf[:bytes])
 
 		if repDataObj.Type == shared.MEASUREMENT_INFO_REPLY {
-			fmt.Printf("\nClient received an TCP Measurement_Info_Reply!!!")
+			fmt.Printf("\nClient received an Measurement_Info_Reply!!!")
 			break
 		}
 	}

--- a/control-plane/ctrl/client-protocols/udp-mcast.go
+++ b/control-plane/ctrl/client-protocols/udp-mcast.go
@@ -4,7 +4,7 @@ import "net"
 import "fmt"
 import "strconv"
 import "os"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 import "io"
 
 const (

--- a/control-plane/ctrl/client-protocols/udp.go
+++ b/control-plane/ctrl/client-protocols/udp.go
@@ -4,7 +4,7 @@ import "net"
 import "fmt"
 import "strconv"
 import "os"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
 // classes
 

--- a/control-plane/ctrl/server-protocols/tcp.go
+++ b/control-plane/ctrl/server-protocols/tcp.go
@@ -4,7 +4,7 @@ import "fmt"
 import "net"
 import "strconv"
 import "os"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 import "io"
 
 // classes

--- a/control-plane/ctrl/server-protocols/udp-mcast.go
+++ b/control-plane/ctrl/server-protocols/udp-mcast.go
@@ -4,7 +4,7 @@ import "fmt"
 import "net"
 import "strconv"
 import "os"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 import "io"
 
 // import "reflect"

--- a/control-plane/ctrl/server-protocols/udp.go
+++ b/control-plane/ctrl/server-protocols/udp.go
@@ -4,7 +4,7 @@ import "fmt"
 import "net"
 import "strconv"
 import "os"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 import "io"
 
 // classes

--- a/management-plane/management-plane.go
+++ b/management-plane/management-plane.go
@@ -5,9 +5,9 @@ import "os"
 import "math/rand"
 import "strings"
 import "strconv"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
-import "github.com/monfron/mapago/measurement-plane/tcp-throughput"
-import "github.com/monfron/mapago/measurement-plane/udp-throughput"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/measurement-plane/tcp-throughput"
+import "github.com/protocollabs/mapago/measurement-plane/udp-throughput"
 
 var msmtStorage map[string]*shared.MsmtStorageEntry
 var mapInited = false

--- a/management-plane/management-plane.go
+++ b/management-plane/management-plane.go
@@ -69,13 +69,15 @@ func constructMsmtId(cltAddr string) string {
 }
 
 func HandleMsmtStopReq(msmtId string) {
-	fmt.Printf("\nMsmtStartReq called!!")
+	fmt.Printf("\nMsmtStopReq called!!")
 
 	msmtEntry, exists := msmtStorage[msmtId]
 	if exists == false {
 		fmt.Printf("\nmsmtEntry for msmtId NOT in storage")
 		os.Exit(1)
 	}
+
+	fmt.Println("\nhandle msmst stop req here")
 
 	switch msmstObj := msmtEntry.MsmtObj.(type) {
 	case *tcpThroughput.TcpMsmtObj:

--- a/management-plane/management-plane.go
+++ b/management-plane/management-plane.go
@@ -78,6 +78,7 @@ func HandleMsmtStopReq(msmtId string) {
 	}
 
 	fmt.Println("\nhandle msmst stop req here")
+	fmt.Println("\nmsmt storage Entry is: ", msmtEntry)
 
 	switch msmstObj := msmtEntry.MsmtObj.(type) {
 	case *tcpThroughput.TcpMsmtObj:

--- a/mapago-client.go
+++ b/mapago-client.go
@@ -261,7 +261,7 @@ func sendUdpMsmtStartRequest(addr string, port int, callSize int) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.MEASUREMENT_START_REQUEST
 	
-	if val, ok := idStorage["udp-id"]; ok {
+	if val, ok := idStorage["tcp-id"]; ok {
 		reqDataObj.Id = val
 	} else {
 		fmt.Println("\nFound not the id")
@@ -352,7 +352,7 @@ func sendUdpMsmtInfoRequest(addr string, port int, callSize int) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.MEASUREMENT_INFO_REQUEST
 	
-	if val, ok := idStorage["udp-id"]; ok {
+	if val, ok := idStorage["tcp-id"]; ok {
 		reqDataObj.Id = val
 	} else {
 		fmt.Println("\nFound not the id")
@@ -372,7 +372,7 @@ func sendUdpMsmtInfoRequest(addr string, port int, callSize int) {
 	// debug fmt.Printf("\nmsmt stop request JSON is: % s", reqJson)
 
 	repDataObj := tcpObj.GetMeasurementInfo(reqJson)
-	fmt.Println("\n\n------------- Client received (TCP) Measurement_Info_reply ------------- \n", repDataObj)
+	fmt.Println("\n\n------------- Client received (UDP) Measurement_Info_reply ------------- \n", repDataObj)
 }
 
 func sendUdpMsmtStopRequest(addr string, port int, callSize int) {
@@ -382,7 +382,7 @@ func sendUdpMsmtStopRequest(addr string, port int, callSize int) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.MEASUREMENT_STOP_REQUEST
 	
-	if val, ok := idStorage["udp-id"]; ok {
+	if val, ok := idStorage["tcp-id"]; ok {
 		reqDataObj.Id = val
 	} else {
 		fmt.Println("\nFound not the id")
@@ -426,8 +426,8 @@ func runUdpCtrlClient(addr string, port int, callSize int, msmtType string) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.INFO_REQUEST
 
-	idStorage["udp-id"] = shared.ConstructId()
-	reqDataObj.Id = idStorage["udp-id"]
+	idStorage["tcp-id"] = shared.ConstructId()
+	reqDataObj.Id = idStorage["tcp-id"]
 
 	reqDataObj.Seq = "0"
 	reqDataObj.Ts = shared.ConvCurrDateToStr()

--- a/mapago-client.go
+++ b/mapago-client.go
@@ -7,10 +7,10 @@ import "os"
 import "sync"
 import "time"
 import "strconv"
-import "github.com/monfron/mapago/control-plane/ctrl/client-protocols"
-import "github.com/monfron/mapago/measurement-plane/tcp-throughput"
-import "github.com/monfron/mapago/measurement-plane/udp-throughput"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/control-plane/ctrl/client-protocols"
+import "github.com/protocollabs/mapago/measurement-plane/tcp-throughput"
+import "github.com/protocollabs/mapago/measurement-plane/udp-throughput"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
 var CTRL_PORT = 64321
 var DEF_BUFFER_SIZE = 8096 * 8

--- a/mapago-client.go
+++ b/mapago-client.go
@@ -332,16 +332,19 @@ func manageUdpMsmt(addr string, port int, callSize int, wg *sync.WaitGroup, clos
 		
 			tMsmtInfoReq.Stop()
 
+			// NOTED: optional we could first send a msmt stop request
+			// wait until the server sockets are down
+			// and then close our own
+			// sendUdpMsmtStopRequest(addr, port, callSize)
+
 			for i := 0; i < workers; i++ {
 				closeConnCh<- "close"
 			}
 
 			wg.Wait()
-			
-			// all connections are now terminated: server should shut down aswell
-			// TODO
-			sendUdpMsmtStopRequest(addr, port, callSize)
 
+			sendUdpMsmtStopRequest(addr, port, callSize)
+			
 			fmt.Println("\nAll udp workers are now finished")
 			return
 		}

--- a/mapago-client.go
+++ b/mapago-client.go
@@ -67,8 +67,12 @@ func runTcpCtrlClient(addr string, port int, callSize int, msmtType string) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.INFO_REQUEST
 
-	idStorage["tcp-id"] = shared.ConstructId()
-	reqDataObj.Id = idStorage["tcp-id"]
+	_, ok := idStorage["host-uuid"]
+	if ok != true {
+		idStorage["host-uuid"] = shared.ConstructId()
+	}
+
+	reqDataObj.Id = idStorage["host-uuid"]
 
 	reqDataObj.Seq = "0"
 	reqDataObj.Ts = shared.ConvCurrDateToStr()
@@ -105,7 +109,7 @@ func sendTcpMsmtStartRequest(addr string, port int, callSize int) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.MEASUREMENT_START_REQUEST
 		
-	if val, ok := idStorage["tcp-id"]; ok {
+	if val, ok := idStorage["host-uuid"]; ok {
 		reqDataObj.Id = val
 	} else {
 		fmt.Println("\nFound not the id")
@@ -194,7 +198,7 @@ func sendTcpMsmtInfoRequest(addr string, port int, callSize int) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.MEASUREMENT_INFO_REQUEST
 	
-	if val, ok := idStorage["tcp-id"]; ok {
+	if val, ok := idStorage["host-uuid"]; ok {
 		reqDataObj.Id = val
 	} else {
 		fmt.Println("\nFound not the id")
@@ -227,7 +231,7 @@ func sendTcpMsmtStopRequest(addr string, port int, callSize int) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.MEASUREMENT_STOP_REQUEST
 	
-	if val, ok := idStorage["tcp-id"]; ok {
+	if val, ok := idStorage["host-uuid"]; ok {
 		reqDataObj.Id = val
 	} else {
 		fmt.Println("\nFound not the id")
@@ -261,7 +265,7 @@ func sendUdpMsmtStartRequest(addr string, port int, callSize int) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.MEASUREMENT_START_REQUEST
 	
-	if val, ok := idStorage["tcp-id"]; ok {
+	if val, ok := idStorage["host-uuid"]; ok {
 		reqDataObj.Id = val
 	} else {
 		fmt.Println("\nFound not the id")
@@ -352,7 +356,7 @@ func sendUdpMsmtInfoRequest(addr string, port int, callSize int) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.MEASUREMENT_INFO_REQUEST
 	
-	if val, ok := idStorage["tcp-id"]; ok {
+	if val, ok := idStorage["host-uuid"]; ok {
 		reqDataObj.Id = val
 	} else {
 		fmt.Println("\nFound not the id")
@@ -382,7 +386,7 @@ func sendUdpMsmtStopRequest(addr string, port int, callSize int) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.MEASUREMENT_STOP_REQUEST
 	
-	if val, ok := idStorage["tcp-id"]; ok {
+	if val, ok := idStorage["host-uuid"]; ok {
 		reqDataObj.Id = val
 	} else {
 		fmt.Println("\nFound not the id")
@@ -426,8 +430,12 @@ func runUdpCtrlClient(addr string, port int, callSize int, msmtType string) {
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.INFO_REQUEST
 
-	idStorage["tcp-id"] = shared.ConstructId()
-	reqDataObj.Id = idStorage["tcp-id"]
+	_, ok := idStorage["host-uuid"]
+	if ok != true {
+		idStorage["host-uuid"] = shared.ConstructId()
+	}
+
+	reqDataObj.Id = idStorage["host-uuid"]
 
 	reqDataObj.Seq = "0"
 	reqDataObj.Ts = shared.ConvCurrDateToStr()

--- a/mapago-server.go
+++ b/mapago-server.go
@@ -3,8 +3,8 @@ package main
 import "fmt"
 import "flag"
 
-//import "github.com/monfron/mapago/controlPlane/cmd/server"
-import "github.com/monfron/mapago/control-plane"
+//import "github.com/protocollabs/mapago/controlPlane/cmd/server"
+import "github.com/protocollabs/mapago/control-plane"
 
 var CTRL_PORT = 64321
 var DEF_BUFFER_SIZE = 8096 * 8

--- a/measurement-plane/tcp-throughput/client.go
+++ b/measurement-plane/tcp-throughput/client.go
@@ -12,7 +12,7 @@ var DEF_BUFFER_SIZE = 8096 * 8
 func NewTcpMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.DataObj, wg *sync.WaitGroup, closeConnCh <-chan string) {
 	lAddr := config.Listen_addr
 
-	fmt.Println("\nDestination listen addr: ", lAddr)
+	fmt.Println("\nTCP Destination listen addr: ", lAddr)
 	serverPorts := shared.ConvStrToIntSlice(msmtStartRep.Measurement.Configuration.UsedPorts)
 
 	for _, port := range serverPorts {
@@ -36,7 +36,7 @@ func tcpClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string)
 			if cmd == "close" {
 				conn.Close()
 				wg.Done()
-				fmt.Println("\nClosing connection")
+				fmt.Println("\nClosing TCP connection")
 				return
 			} else {
 				fmt.Printf("\nTcpClient worker did not understand cmd: %s", cmd)

--- a/measurement-plane/tcp-throughput/client.go
+++ b/measurement-plane/tcp-throughput/client.go
@@ -5,7 +5,7 @@ import "net"
 import "os"
 import "strconv"
 import "fmt"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
 var DEF_BUFFER_SIZE = 8096 * 8
 

--- a/measurement-plane/tcp-throughput/server.go
+++ b/measurement-plane/tcp-throughput/server.go
@@ -49,7 +49,7 @@ func NewTcpMsmtObj(msmtCh <-chan shared.ChMgmt2Msmt, ctrlCh chan<- shared.ChMsmt
 	tcpMsmt.fTsStorage = make(map[string]string)
 	tcpMsmt.lTsStorage = make(map[string]string)
 
-	fmt.Println("\nClient request is: ", msmtStartReq)
+	fmt.Println("\nClient TCP request is: ", msmtStartReq)
 
 	tcpMsmt.numStreams, err = strconv.Atoi(msmtStartReq.Measurement.Configuration.Worker)
 	if err != nil {

--- a/measurement-plane/tcp-throughput/server.go
+++ b/measurement-plane/tcp-throughput/server.go
@@ -5,7 +5,7 @@ import "os"
 import "net"
 import "strconv"
 import "sync"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
 var UPDATE_INTERVAL = 5
 

--- a/measurement-plane/udp-throughput/client.go
+++ b/measurement-plane/udp-throughput/client.go
@@ -17,7 +17,7 @@ func NewUdpMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.DataO
 
 	for _, port := range serverPorts {
 		listen := lAddr + ":" + strconv.Itoa(port)
-		// debug fmt.Println("\nCommunicating with: ", listen)
+		fmt.Println("\nCommunicating with: ", listen)
 		wg.Add(1)
 		go udpClientWorker(listen, wg, closeConnCh)
 	}
@@ -44,7 +44,7 @@ func udpClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string)
 			}
 		default:
 			_, err := conn.Write(buf)
-			
+
 			if err != nil {
 				fmt.Printf("\nWrite error: %s", err)
 				os.Exit(1)

--- a/measurement-plane/udp-throughput/client.go
+++ b/measurement-plane/udp-throughput/client.go
@@ -1,1 +1,53 @@
 package udpThroughput
+
+import "sync"
+import "net"
+import "os"
+import "strconv"
+import "fmt"
+import "github.com/monfron/mapago/control-plane/ctrl/shared"
+
+var DEF_BUFFER_SIZE = 8096 * 8
+
+func NewUdpMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.DataObj, wg *sync.WaitGroup, closeConnCh <-chan string) {
+	lAddr := config.Listen_addr
+
+	fmt.Println("\nUDP Destination listen addr: ", lAddr)
+	serverPorts := shared.ConvStrToIntSlice(msmtStartRep.Measurement.Configuration.UsedPorts)
+
+	for _, port := range serverPorts {
+		listen := lAddr + ":" + strconv.Itoa(port)
+		// debug fmt.Println("\nCommunicating with: ", listen)
+		wg.Add(1)
+		go udpClientWorker(listen, wg, closeConnCh)
+	}
+}
+
+func udpClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string) {
+	buf := make([]byte, DEF_BUFFER_SIZE, DEF_BUFFER_SIZE)
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		panic("dial")
+	}
+
+	for {
+		select {
+		case cmd := <-closeConnCh:
+			if cmd == "close" {
+				conn.Close()
+				wg.Done()
+				fmt.Println("\nClosing UDP connection")
+				return
+			} else {
+				fmt.Printf("\nudpClient worker did not understand cmd: %s", cmd)
+				os.Exit(1)
+			}
+		default:
+			_, err := conn.Write(buf)
+			if err != nil {
+				fmt.Printf("\nWrite error: %s", err)
+				os.Exit(1)
+			}
+		}
+	}
+}

--- a/measurement-plane/udp-throughput/client.go
+++ b/measurement-plane/udp-throughput/client.go
@@ -5,7 +5,7 @@ import "net"
 import "os"
 import "strconv"
 import "fmt"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
 var DEF_BUFFER_SIZE = 8096 * 8
 

--- a/measurement-plane/udp-throughput/client.go
+++ b/measurement-plane/udp-throughput/client.go
@@ -44,6 +44,7 @@ func udpClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string)
 			}
 		default:
 			_, err := conn.Write(buf)
+			
 			if err != nil {
 				fmt.Printf("\nWrite error: %s", err)
 				os.Exit(1)

--- a/measurement-plane/udp-throughput/server.go
+++ b/measurement-plane/udp-throughput/server.go
@@ -146,6 +146,8 @@ func (udpMsmt *UdpThroughputMsmt) udpServerWorker(closeCh <-chan interface{}, go
 				os.Exit(1)
 			}
 
+			fmt.Println("\nudp server worker close here")
+
 			if cmd != "close" {
 				fmt.Printf("Wrong cmd: Looking for close cmd")
 				os.Exit(1)
@@ -155,16 +157,23 @@ func (udpMsmt *UdpThroughputMsmt) udpServerWorker(closeCh <-chan interface{}, go
 			udpConn.Close()
 			return
 		default:
+
+			// debug fmt.Println("\nright before read from udp")
 			bytes, cltAddr, error := udpConn.ReadFromUDP(message)
 			if error != nil {
 				fmt.Printf("Cannot read: %s\n", error)
 				os.Exit(1)
 			}
+			
+			// debug fmt.Println("\nright after read from udp")
+			
 
 			if cltAddrExists == false {
 				fmt.Println("\nConnection from: ", cltAddr)
 				cltAddrExists = true
 			}
+
+			fmt.Println("\nudp server worker data here")
 
 			udpMsmt.writeByteStorage(stream, uint64(bytes))
 
@@ -227,8 +236,12 @@ func (udpMsmt *UdpThroughputMsmt) CloseConn() {
 	var msmtData map[string]string
 
 	for i := 0; i < udpMsmt.numStreams; i++ {
+		fmt.Println("\n!!!!close conn func udp here")
+
 		udpMsmt.closeConnCh <- "close"
 	}
+
+	fmt.Println("\nhello2")
 
 	msmtReply := new(shared.ChMsmt2Ctrl)
 	msmtReply.Status = "ok"

--- a/measurement-plane/udp-throughput/server.go
+++ b/measurement-plane/udp-throughput/server.go
@@ -133,8 +133,6 @@ func (udpMsmt *UdpThroughputMsmt) udpServerWorker(closeCh <-chan interface{}, go
 		port++
 	}
 
-	// TODO maybe that does not work at that point
-	// fmt.Printf("Connection from %s\n", udpConn.RemoteAddr())
 	message := make([]byte, udpMsmt.callSize, udpMsmt.callSize)
 
 	for {
@@ -164,16 +162,15 @@ func (udpMsmt *UdpThroughputMsmt) udpServerWorker(closeCh <-chan interface{}, go
 				fmt.Printf("Cannot read: %s\n", error)
 				os.Exit(1)
 			}
-			
+
 			// debug fmt.Println("\nright after read from udp")
-			
 
 			if cltAddrExists == false {
 				fmt.Println("\nConnection from: ", cltAddr)
 				cltAddrExists = true
 			}
 
-			fmt.Println("\nudp server worker data here")
+			// debug fmt.Println("\nudp server worker data here")
 
 			udpMsmt.writeByteStorage(stream, uint64(bytes))
 

--- a/measurement-plane/udp-throughput/server.go
+++ b/measurement-plane/udp-throughput/server.go
@@ -109,7 +109,6 @@ func (udpMsmt *UdpThroughputMsmt) udpServerWorker(closeCh <-chan interface{}, go
 	fTsExists := false
 	cltAddrExists := false
 	readCh := make(chan int)
-
 	stream := "stream" + strconv.Itoa(streamIndex)
 	fmt.Printf("\n%s is here", stream)
 

--- a/measurement-plane/udp-throughput/server.go
+++ b/measurement-plane/udp-throughput/server.go
@@ -10,17 +10,19 @@ import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 var UPDATE_INTERVAL = 5
 
 type UdpThroughputMsmt struct {
-	numStreams       int
-	usedPorts        []int
-	callSize         int
-	listenAddr       string
-	msmtId           string
-	byteStorage      map[string]uint64
-	byteStorageMutex sync.RWMutex
-	fTsStorage       map[string]string
-	fTsStorageMutex  sync.RWMutex
-	lTsStorage       map[string]string
-	lTsStorageMutex  sync.RWMutex
+	numStreams          int
+	usedPorts           []int
+	callSize            int
+	listenAddr          string
+	msmtId              string
+	byteStorage         map[string]uint64
+	byteStorageMutex    sync.RWMutex
+	fTsStorage          map[string]string
+	fTsStorageMutex     sync.RWMutex
+	lTsStorage          map[string]string
+	lTsStorageMutex     sync.RWMutex
+	udpConnStorage      map[string]*net.UDPConn
+	udpConnStorageMutex sync.RWMutex
 
 	/*
 		- this attribute can be used by start() to RECEIVE cmd from managementplane
@@ -48,6 +50,7 @@ func NewUdpThroughputMsmt(msmtCh <-chan shared.ChMgmt2Msmt, ctrlCh chan<- shared
 	udpMsmt.byteStorage = make(map[string]uint64)
 	udpMsmt.fTsStorage = make(map[string]string)
 	udpMsmt.lTsStorage = make(map[string]string)
+	udpMsmt.udpConnStorage = make(map[string]*net.UDPConn)
 
 	fmt.Println("\nClient UDP request is: ", msmtStartReq)
 
@@ -108,7 +111,6 @@ func (udpMsmt *UdpThroughputMsmt) udpServerWorker(closeCh <-chan interface{}, go
 	var udpConn *net.UDPConn
 	fTsExists := false
 	cltAddrExists := false
-	readCh := make(chan int)
 	stream := "stream" + strconv.Itoa(streamIndex)
 	fmt.Printf("\n%s is here", stream)
 
@@ -126,6 +128,9 @@ func (udpMsmt *UdpThroughputMsmt) udpServerWorker(closeCh <-chan interface{}, go
 		if error == nil {
 			// debug fmt.Printf("\nCan listen on addr: %s\n", listen)
 			udpMsmt.usedPorts = append(udpMsmt.usedPorts, port)
+
+			udpMsmt.writeUdpConnStorage(stream, udpConn)
+
 			goHeartbeatCh <- true
 			break
 		}
@@ -137,69 +142,37 @@ func (udpMsmt *UdpThroughputMsmt) udpServerWorker(closeCh <-chan interface{}, go
 	message := make([]byte, udpMsmt.callSize, udpMsmt.callSize)
 
 	// 2. create go func to read asynchronously
-	go func(readCh chan<- int) {
-		for {
-			bytes, cltAddr, error := udpConn.ReadFromUDP(message)
-			if error != nil {
-
-				// differ cases of error
-				if error.(*net.OpError).Err.Error() == "use of closed network connection" {
-					// debug fmt.Println("\nClosed network detected! I am ignoring this")
-					break
-				}
-
-				fmt.Printf("Udp server worker! Cannot read: %s\n", error)
-				os.Exit(1)
-			}
-
-			if cltAddrExists == false {
-				fmt.Println("\nConnection from: ", cltAddr)
-				cltAddrExists = true
-			}
-
-			readCh <- bytes
-		}
-	}(readCh)
-
-	// 3. for loop and select
 	for {
-		select {
-		// ok, there is data to read!
-		case bytes := <-readCh:
-			udpMsmt.writeByteStorage(stream, uint64(bytes))
+		bytes, cltAddr, error := udpConn.ReadFromUDP(message)
+		if error != nil {
 
-			// maybe we could also do this when receing the actual data
-			if fTsExists == false {
-				fTs := shared.ConvCurrDateToStr()
-				udpMsmt.writefTsStorage(stream, fTs)
-				fTsExists = true
+			if error.(*net.OpError).Err.Error() == "use of closed network connection" {
+				// debug fmt.Println("\nClosed network detected! I am ignoring this")
+				break
 			}
 
-			lTs := shared.ConvCurrDateToStr()
-			udpMsmt.writelTsStorage(stream, lTs)
-
-		// ok, i received a close cmd: tear the socket down
-		// PROBLEM: the asyncronous goroutine still reads from the socket
-		// result: read from closed connection
-		case data := <-closeCh:
-			cmd, ok := data.(string)
-			if ok == false {
-				fmt.Printf("Type assertion failed: Looking for string %t", ok)
-				os.Exit(1)
-			}
-
-			if cmd != "close" {
-				fmt.Printf("Wrong cmd: Looking for close cmd")
-				os.Exit(1)
-			}
-			// debug:
-			fmt.Printf("\nClosing udpConn for stream %s", stream)
-			udpConn.Close()
-
-			return
+			fmt.Printf("Udp server worker! Cannot read: %s\n", error)
+			os.Exit(1)
 		}
+
+		if cltAddrExists == false {
+			fmt.Println("\nConnection from: ", cltAddr)
+			cltAddrExists = true
+		}
+
+		udpMsmt.writeByteStorage(stream, uint64(bytes))
+
+		if fTsExists == false {
+			fTs := shared.ConvCurrDateToStr()
+			udpMsmt.writefTsStorage(stream, fTs)
+			fTsExists = true
+		}
+
+		lTs := shared.ConvCurrDateToStr()
+		udpMsmt.writelTsStorage(stream, lTs)
 	}
 }
+
 func (udpMsmt *UdpThroughputMsmt) writefTsStorage(stream string, ts string) {
 	udpMsmt.fTsStorageMutex.Lock()
 	udpMsmt.fTsStorage[stream] = ts
@@ -243,11 +216,25 @@ func (udpMsmt *UdpThroughputMsmt) readByteStorage(stream string) uint64 {
 	return bytes
 }
 
+func (udpMsmt *UdpThroughputMsmt) writeUdpConnStorage(stream string, sock *net.UDPConn) {
+	udpMsmt.udpConnStorageMutex.Lock()
+	udpMsmt.udpConnStorage[stream] = sock
+	udpMsmt.udpConnStorageMutex.Unlock()
+}
+
+func (udpMsmt *UdpThroughputMsmt) readUdpConnStorage(stream string) *net.UDPConn {
+	udpMsmt.udpConnStorageMutex.RLock()
+	sock := udpMsmt.udpConnStorage[stream]
+	udpMsmt.udpConnStorageMutex.RUnlock()
+	return sock
+}
+
 func (udpMsmt *UdpThroughputMsmt) CloseConn() {
 	var msmtData map[string]string
 
-	for i := 0; i < udpMsmt.numStreams; i++ {
-		udpMsmt.closeConnCh <- "close"
+	for streamId, sock := range udpMsmt.udpConnStorage {
+		fmt.Println("\nUDP closing: ", streamId)
+		sock.Close()
 	}
 
 	msmtReply := new(shared.ChMsmt2Ctrl)
@@ -258,8 +245,6 @@ func (udpMsmt *UdpThroughputMsmt) CloseConn() {
 	msmtData["msg"] = "all modules closed"
 	msmtReply.Data = msmtData
 
-	// NOTE: can we ensure that all conns are torn down until
-	// this asynchronous call is executed?!
 	go func() {
 		udpMsmt.msmt2CtrlCh <- *msmtReply
 	}()

--- a/measurement-plane/udp-throughput/server.go
+++ b/measurement-plane/udp-throughput/server.go
@@ -5,7 +5,7 @@ import "os"
 import "net"
 import "sync"
 import "strconv"
-import "github.com/monfron/mapago/control-plane/ctrl/shared"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
 var UPDATE_INTERVAL = 5
 

--- a/measurement-plane/udp-throughput/server.go
+++ b/measurement-plane/udp-throughput/server.go
@@ -142,6 +142,13 @@ func (udpMsmt *UdpThroughputMsmt) udpServerWorker(closeCh <-chan interface{}, go
 		for {
 			bytes, cltAddr, error := udpConn.ReadFromUDP(message)
 			if error != nil {
+
+				// differ cases of error
+				if error.(*net.OpError).Err.Error() == "use of closed network connection" {
+					// debug fmt.Println("\nClosed network detected! I am ignoring this")
+					break
+				}
+
 				fmt.Printf("Udp server worker! Cannot read: %s\n", error)
 				os.Exit(1)
 			}

--- a/measurement-plane/udp-throughput/server.go
+++ b/measurement-plane/udp-throughput/server.go
@@ -49,7 +49,7 @@ func NewUdpThroughputMsmt(msmtCh <-chan shared.ChMgmt2Msmt, ctrlCh chan<- shared
 	udpMsmt.fTsStorage = make(map[string]string)
 	udpMsmt.lTsStorage = make(map[string]string)
 
-	fmt.Println("\nClient request is: ", msmtStartReq)
+	fmt.Println("\nClient UDP request is: ", msmtStartReq)
 
 	udpMsmt.numStreams, err = strconv.Atoi(msmtStartReq.Measurement.Configuration.Worker)
 	if err != nil {


### PR DESCRIPTION
- The following is ADDED:
     - client netcode for udp-throughput msmt
     - server netcode for udp-throughput msmt
- The following is FIXED:
     - at the server side the select + default (incl. read operation) statement 
     is removed for Tcp and Udp msmt
     - as a result: the default case does not block "infinitly" => the close cmd can be received
- The following is TESTED:
     - Tcp standalone
     - UDP standalone
     - Tcp multiple operations
     - Udp multiple operation
     - Tcp and udp mixed
- WHAT DOES NOT WORK:
     - Still I didnt changed the makefile 
     - Still the relative path is not included 
(c.f. https://stackoverflow.com/questions/38517593/relative-imports-in-go)
     - to BUILD THE PROJECT perform: make install