### PR TITLE
Fixed: Evaluation.py, loopback bug, cli naming Tested: Evaluation, Added: QUIC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ mapago-server
 release/
 
 *.swp
+*.png

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GOBIN   :=$(GOPATH)/bin
 
 MKDIR_P = @mkdir -p
 
+# notice that
 LDFLAGS  = "-X $(PACKAGE)/core.BuildVersion=$(VERSION) -X $(PACKAGE)/core.BuildDate=$(DATE)"
 
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
@@ -16,11 +17,8 @@ SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 all: $(TARGET)
 
 $(TARGET): $(SRC)
-	go build mapago-server.go
-	go build mapago-client.go
-	# FIME, the previous two lines fixed the build problem.
-	# but the next with ldflags is still missing, must be added
-	#go build -ldflags $(LDFLAGS) -o $(TARGET) cmd/mapago/mapago.go
+	go build -ldflags $(LDFLAGS) mapago-server.go
+	go build -ldflags $(LDFLAGS) mapago-client.go
 
 XYZs = windows:amd64 linux:arm64
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Execute the following installation steps to use Mapago:
 ```
 export GOPATH=$HOME/go
 export GOBIN=$HOME/go/bin
+go get github.com/google/uuid
 go get github.com/protocollabs/mapago
 cd $GOPATH/github.com/protocollabs/mapago
 make install

--- a/control-plane/control-plane.go
+++ b/control-plane/control-plane.go
@@ -257,8 +257,9 @@ func constructMsmtInfoReply(reqDataObj *shared.DataObj, msmtRep shared.ChMsmt2Ct
 func supportedModules() map[string]string {
 	fmt.Println("\nConstructing supported modules")
 	supportedMods := make(map[string]string)
-	supportedMods["udp-goodput"] = "no-support"
-	supportedMods["tcp-goodput"] = "no-support"
+	supportedMods["udp-goodput"] = "supported"
+	supportedMods["tcp-goodput"] = "supported"
+	supportedMods["quic-goodput"] = "not-supported"
 	// TODO: Bring that up to data
 	return supportedMods
 }

--- a/control-plane/control-plane.go
+++ b/control-plane/control-plane.go
@@ -219,15 +219,15 @@ func constructMsmtStopReply(reqDataObj *shared.DataObj, msmtRep shared.ChMsmt2Ct
 	repDataObj.Id = ID
 	repDataObj.Seq_rp = reqDataObj.Seq
 
-	msmtData, ok := msmtRep.Data.(map[string]string)
+	combined, ok := msmtRep.Data.(shared.CombinedData)
 	if ok == false {
-		fmt.Printf("Type assertion failed: Looking for map %t", ok)
+		fmt.Printf("Type assertion failed: Looking for combined data %t", ok)
 		os.Exit(1)
 	}
 
-	repDataObj.Measurement_id = msmtData["msmtId"]
-	repDataObj.Message = msmtData["msg"]
-	// TODO: Include the final measurement result
+	repDataObj.Measurement_id = combined.MgmtData["msmtId"]
+	repDataObj.Message = combined.MgmtData["msg"]
+	repDataObj.Data.DataElements = combined.MsmtData
 
 	return repDataObj
 }

--- a/control-plane/control-plane.go
+++ b/control-plane/control-plane.go
@@ -259,5 +259,6 @@ func supportedModules() map[string]string {
 	supportedMods := make(map[string]string)
 	supportedMods["udp-goodput"] = "no-support"
 	supportedMods["tcp-goodput"] = "no-support"
+	// TODO: Bring that up to data
 	return supportedMods
 }

--- a/control-plane/control-plane.go
+++ b/control-plane/control-plane.go
@@ -248,7 +248,7 @@ func constructMsmtInfoReply(reqDataObj *shared.DataObj, msmtRep shared.ChMsmt2Ct
 	}
 
 	repDataObj.Measurement_id = reqDataObj.Measurement_id
-	repDataObj.Data.DataElement = msmtData
+	repDataObj.Data.DataElements = msmtData
 
 	// TODO: Add the timestamps
 	return repDataObj

--- a/control-plane/ctrl/shared/common-funcs.go
+++ b/control-plane/ctrl/shared/common-funcs.go
@@ -4,7 +4,6 @@ import "fmt"
 import "encoding/json"
 import "encoding/binary"
 import "os"
-import "os/exec"
 import "strings"
 import "bytes"
 import "time"
@@ -12,6 +11,7 @@ import "runtime"
 import "path/filepath"
 import "strconv"
 import "math/rand"
+import "github.com/google/uuid"
 
 const DATE_FMT = "2006-01-02T15:04:05.000000"
 
@@ -100,15 +100,12 @@ func ConstructId() string {
 		os.Exit(1)
 	}
 
-	uuid, err := exec.Command("uuidgen").Output()
-	if err != nil {
-		fmt.Printf("Cannot construct uuid %s\n", err)
-		os.Exit(1)
-	}
+	uuid := uuid.New().String()
 
 	id := []string{}
 	id = append(id, hostName)
-	id = append(id, strings.TrimSuffix(string(uuid[:]), "\n"))
+	id = append(id, uuid)
+
 	return strings.Join(id, "=")
 }
 

--- a/control-plane/ctrl/shared/common-funcs.go
+++ b/control-plane/ctrl/shared/common-funcs.go
@@ -13,7 +13,7 @@ import "path/filepath"
 import "strconv"
 import "math/rand"
 
-const DATE_FMT = "2006-01-02 15:04:05.000000000"
+const DATE_FMT = "2006-01-02T15:04:05.000000"
 
 func ConvJsonToDataStruct(jsonData []byte) *DataObj {
 	dataObj := new(DataObj)

--- a/control-plane/ctrl/shared/ctrl-msg.go
+++ b/control-plane/ctrl/shared/ctrl-msg.go
@@ -115,7 +115,7 @@ type ConfigurationObj struct {
 }
 
 type DataCollectionObj struct {
-	DataElement []DataResultObj
+	DataElements []DataResultObj
 }
 
 type DataResultObj struct {

--- a/control-plane/ctrl/shared/ctrl-msg.go
+++ b/control-plane/ctrl/shared/ctrl-msg.go
@@ -57,6 +57,11 @@ type ChMsmtResult struct {
 	Time  float64
 }
 
+type CombinedData struct {
+	MgmtData map[string]string
+	MsmtData []DataResultObj
+}
+
 type MsmtStorageEntry struct {
 	MsmtCh chan ChMgmt2Msmt
 	// this could be: tcpMsmtObj, udpMsmtObj, quicMsmtObj
@@ -124,6 +129,7 @@ type DataResultObj struct {
 	Received_bytes  string `json:",omitempty"`
 }
 
+// this is the per msmt module allocated "storage" for the gathered msmt data
 type MsmtInfoObj struct {
 	Bytes   uint64
 	FirstTs string

--- a/control-plane/ctrl/shared/ctrl-msg.go
+++ b/control-plane/ctrl/shared/ctrl-msg.go
@@ -1,6 +1,7 @@
 package shared
 
 import "net"
+import quic "github.com/lucas-clemente/quic-go"
 
 // channel result
 
@@ -143,4 +144,10 @@ type TcpConnObj struct {
 
 type UdpConn struct {
 	SrvSock *net.UDPConn
+}
+
+type QuicConn struct {
+	AcceptSock quic.Session
+	// holds the underlying ListenUDP sock
+	SrvSock quic.Listener
 }

--- a/management-plane/management-plane.go
+++ b/management-plane/management-plane.go
@@ -57,6 +57,9 @@ func HandleMsmtStartReq(ctrlCh chan<- shared.ChMsmt2Ctrl, msmtStartReq *shared.D
 		msmtStorage[msmtId] = msmtEntry
 
 		fmt.Println("\nmsmtStorage content: ", msmtStorage)
+
+		// TODO1: Add QUIC support
+
 	}
 }
 
@@ -85,7 +88,7 @@ func HandleMsmtStopReq(msmtId string) {
 		msmstObj.CloseConn()
 	case *udpThroughput.UdpThroughputMsmt:
 		msmstObj.CloseConn()
-	// TODO	case *quicThroughput.QuicMsmtObj:
+	// TODO2:	case *quicThroughput.QuicMsmtObj:
 	default:
 		fmt.Printf("Type assertion failed: Unknown msmt type")
 		os.Exit(1)
@@ -108,7 +111,7 @@ func HandleMsmtInfoReq(msmtId string) {
 		msmstObj.GetMsmtInfo()
 	case *udpThroughput.UdpThroughputMsmt:
 		msmstObj.GetMsmtInfo()
-	// TODO	case *quicThroughput.QuicMsmtObj:
+	// TODO3: 	case *quicThroughput.QuicMsmtObj:
 	default:
 		fmt.Printf("Type assertion failed: Unknown msmt type")
 		os.Exit(1)

--- a/management-plane/management-plane.go
+++ b/management-plane/management-plane.go
@@ -129,6 +129,7 @@ func HandleMsmtInfoReq(msmtId string) {
 	case *udpThroughput.UdpThroughputMsmt:
 		msmstObj.GetMsmtInfo()
 	case *quicThroughput.QuicThroughputMsmt:
+		msmstObj.GetMsmtInfo()
 	default:
 		fmt.Printf("Type assertion failed: Unknown msmt type")
 		os.Exit(1)

--- a/mapago-client.go
+++ b/mapago-client.go
@@ -251,9 +251,9 @@ func sendTcpMsmtStopRequest(addr string, port int, callSize int) {
 	reqJson := shared.ConvDataStructToJson(reqDataObj)
 	// debug fmt.Printf("\nmsmt stop request JSON is: % s", reqJson)
 
-	tcpObj.StopMeasurement(reqJson)
+	msmtStopRep := tcpObj.StopMeasurement(reqJson)
+	prepareOutput(msmtStopRep)
 }
-
 
 // this starts the UDP throughput measurement
 // underlying control channel is TCP based
@@ -390,7 +390,8 @@ func sendUdpMsmtStopRequest(addr string, port int, callSize int) {
 	}
 
 	reqJson := shared.ConvDataStructToJson(reqDataObj)
-	tcpObj.StopMeasurement(reqJson)
+	msmtStopRep := tcpObj.StopMeasurement(reqJson)
+	prepareOutput(msmtStopRep)
 }
 
 func constructMeasurementObj(name string, module string) *shared.MeasurementObj {

--- a/mapago-client.go
+++ b/mapago-client.go
@@ -113,8 +113,6 @@ func runTcpCtrlClient(addr string, port int, callSize int, module string) {
 }
 
 func sendQuicMsmtStartRequest(addr string, port int, callSize int) {
-	fmt.Println("\nSending a msmt start request!!!")
-
 	var wg sync.WaitGroup
 	closeConnCh := make(chan string)
 	tcpObj := clientProtos.NewTcpObj("QuicMsmtStartReqConn", addr, port, callSize)
@@ -194,9 +192,6 @@ func manageQuicMsmt(addr string, port int, callSize int, wg *sync.WaitGroup, clo
 func sendQuicMsmtInfoRequest(addr string, port int, callSize int) {
 	tcpObj := clientProtos.NewTcpObj("QuicMsmtInfoReqConn", addr, port, callSize)
 
-	fmt.Println("\nSending a msmt info request!!!")
-
-
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.MEASUREMENT_INFO_REQUEST
 	
@@ -228,9 +223,6 @@ func sendQuicMsmtInfoRequest(addr string, port int, callSize int) {
 // underlying control channel is TCP based
 func sendQuicMsmtStopRequest(addr string, port int, callSize int) {
 	tcpObj := clientProtos.NewTcpObj("QuicMsmtStopReqConn", addr, port, callSize)
-
-	fmt.Println("\nSending a msmt stop request!!!")
-
 
 	reqDataObj := new(shared.DataObj)
 	reqDataObj.Type = shared.MEASUREMENT_STOP_REQUEST

--- a/mapago-client.go
+++ b/mapago-client.go
@@ -104,10 +104,18 @@ func runTcpCtrlClient(addr string, port int, callSize int, module string) {
 		sendTcpMsmtStartRequest(addr, port, callSize)
 	} else if module == "udp-throughput" {
 		sendUdpMsmtStartRequest(addr, port, callSize)
+	// TODO: ADD QUIC
 	} else {
 		panic("Measurement type not supported")
 	}
 }
+
+// TODO1: sendQuicMsmtStartRequest
+// TODO2: manageQUICMsmt
+// TODO3: sendQuicMsmtInfoRequest
+// TODO4: sendQuicMsmtStopRequest
+
+
 
 // this starts the TCP throughput measurement
 // underlying control channel is TCP based
@@ -447,6 +455,7 @@ func runUdpCtrlClient(addr string, port int, callSize int, module string) {
 		sendTcpMsmtStartRequest(addr, port, callSize)
 	} else if module == "udp-throughput" {
 		sendUdpMsmtStartRequest(addr, port, callSize)
+	// TODO6: Add QUIC	
 	} else {
 		panic("Measurement type not supported")
 	}
@@ -484,6 +493,7 @@ func runUdpMcastCtrlClient(addr string, port int, callSize int, module string) {
 		sendTcpMsmtStartRequest(addr, port, callSize)
 	} else if module == "udp-throughput" {
 		sendUdpMsmtStartRequest(addr, port, callSize)
+	// TODO: Add Quic	
 	} else {
 		panic("Measurement type not supported")
 	}

--- a/measurement-plane/quic-throughput/client.go
+++ b/measurement-plane/quic-throughput/client.go
@@ -1,0 +1,1 @@
+package quicThroughput

--- a/measurement-plane/quic-throughput/client.go
+++ b/measurement-plane/quic-throughput/client.go
@@ -1,1 +1,62 @@
 package quicThroughput
+
+import "sync"
+import "os"
+import "strconv"
+import "fmt"
+import "crypto/tls"
+import quic "github.com/lucas-clemente/quic-go"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
+
+var DEF_BUFFER_SIZE = 8096 * 8
+
+func NewQuicMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.DataObj, wg *sync.WaitGroup, closeConnCh <-chan string) {
+	lAddr := config.Listen_addr
+	serverPorts := shared.ConvStrToIntSlice(msmtStartRep.Measurement.Configuration.UsedPorts)
+
+	for _, port := range serverPorts {
+		listen := lAddr + ":" + strconv.Itoa(port)
+		wg.Add(1)
+		go quicClientWorker(listen, wg, closeConnCh)
+	}
+}
+
+func quicClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string) {
+	buf := make([]byte, DEF_BUFFER_SIZE, DEF_BUFFER_SIZE)
+
+	// create tls config
+	tlsConf := tls.Config{InsecureSkipVerify: true}
+
+	// replace that with quic.DialAddr
+	session, err := quic.DialAddr(addr, &tlsConf, nil)
+	if err != nil {
+		panic("dial")
+	}
+
+	stream, err := session.OpenStreamSync()
+	if err != nil {
+		panic("openStream")
+	}
+
+	for {
+		select {
+		case cmd := <-closeConnCh:
+			if cmd == "close" {
+				// replace that with session.Close()
+				session.Close()
+				wg.Done()
+				return
+			} else {
+				fmt.Printf("\nTcpClient worker did not understand cmd: %s", cmd)
+				os.Exit(1)
+			}
+		default:
+			// replace that with stream.Write(buf)
+			_, err := stream.Write(buf)
+			if err != nil {
+				fmt.Printf("\nWrite error: %s", err)
+				os.Exit(1)
+			}
+		}
+	}
+}

--- a/measurement-plane/quic-throughput/client.go
+++ b/measurement-plane/quic-throughput/client.go
@@ -24,10 +24,8 @@ func NewQuicMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.Data
 func quicClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string) {
 	buf := make([]byte, DEF_BUFFER_SIZE, DEF_BUFFER_SIZE)
 
-	// create tls config
 	tlsConf := tls.Config{InsecureSkipVerify: true}
 
-	// replace that with quic.DialAddr
 	session, err := quic.DialAddr(addr, &tlsConf, nil)
 	if err != nil {
 		panic("dial")
@@ -42,7 +40,6 @@ func quicClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string
 		select {
 		case cmd := <-closeConnCh:
 			if cmd == "close" {
-				// replace that with session.Close()
 				session.Close()
 				wg.Done()
 				return

--- a/measurement-plane/quic-throughput/server.go
+++ b/measurement-plane/quic-throughput/server.go
@@ -1,1 +1,274 @@
 package quicThroughput
+
+import "fmt"
+import "os"
+import "strconv"
+import "crypto/tls"
+import "crypto/rsa"
+import "crypto/rand"
+import "crypto/x509"
+import "math/big"
+import "encoding/pem"
+import "io"
+import quic "github.com/lucas-clemente/quic-go"
+import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
+
+type QuicThroughputMsmt struct {
+	numStreams      int
+	usedPorts       []int
+	callSize        int
+	listenAddr      string
+	msmtId          string
+	msmtInfoStorage map[string]*shared.MsmtInfoObj
+	connStorage     map[string]*shared.QuicConn
+
+	/*
+		- this attribute can be used by start() to RECEIVE cmd from managementplane
+	*/
+	msmtMgmt2MsmtCh <-chan shared.ChMgmt2Msmt
+
+	/*
+		- this attribute can be used by constructor and start() to SEND msgs to control plane
+	*/
+	msmt2CtrlCh chan<- shared.ChMsmt2Ctrl
+
+	/*
+		- channel for closing connection
+	*/
+	closeConnCh chan interface{}
+}
+
+func NewQuicThroughputMsmt(msmtCh <-chan shared.ChMgmt2Msmt, ctrlCh chan<- shared.ChMsmt2Ctrl, msmtStartReq *shared.DataObj, msmtId string, startPort int) *QuicThroughputMsmt {
+	var err error
+	var msmtData map[string]string
+	heartbeatCh := make(chan bool)
+	closeCh := make(chan interface{})
+	quicMsmt := new(QuicThroughputMsmt)
+
+	quicMsmt.msmtInfoStorage = make(map[string]*shared.MsmtInfoObj)
+	quicMsmt.connStorage = make(map[string]*shared.QuicConn)
+	fmt.Println("\nClient QUIC request is: ", msmtStartReq)
+
+	quicMsmt.numStreams, err = strconv.Atoi(msmtStartReq.Measurement.Configuration.Worker)
+	if err != nil {
+		fmt.Printf("\nCannot convert worker value: %s", err)
+		os.Exit(1)
+	}
+
+	quicMsmt.callSize, err = strconv.Atoi(msmtStartReq.Measurement.Configuration.Call_size)
+	if err != nil {
+		fmt.Printf("\nCannot convert callSize value: %s", err)
+		os.Exit(1)
+	}
+
+	quicMsmt.msmtId = msmtId
+	quicMsmt.listenAddr = msmtStartReq.Measurement.Configuration.Listen_addr
+	quicMsmt.msmtMgmt2MsmtCh = msmtCh
+	quicMsmt.msmt2CtrlCh = ctrlCh
+	quicMsmt.closeConnCh = closeCh
+
+	for c := 1; c <= quicMsmt.numStreams; c++ {
+		stream := "stream" + strconv.Itoa(c)
+
+		msmtInfo := shared.MsmtInfoObj{}
+		quicMsmt.msmtInfoStorage[stream] = &msmtInfo
+
+		quicConns := shared.QuicConn{}
+		quicMsmt.connStorage[stream] = &quicConns
+
+		go quicMsmt.quicServerWorker(closeCh, heartbeatCh, startPort, c, &msmtInfo, &quicConns)
+	}
+
+	for c := 1; c <= quicMsmt.numStreams; c++ {
+		heartbeat := <-heartbeatCh
+		if heartbeat != true {
+			panic("quic_server_worker goroutine not ok")
+		}
+	}
+
+	fmt.Println("\n\nPorts used by quic module: ", quicMsmt.usedPorts)
+
+	msmtReply := new(shared.ChMsmt2Ctrl)
+	msmtReply.Status = "ok"
+
+	msmtData = make(map[string]string)
+	msmtData["msmtId"] = quicMsmt.msmtId
+	msmtData["msg"] = "all modules running"
+	msmtData["usedPorts"] = shared.ConvIntSliceToStr(quicMsmt.usedPorts)
+
+	msmtReply.Data = msmtData
+
+	/*
+		NOTE: I dont get why exactly we need to perform this as a goroutine
+		- we use unbuffered channels so chan<- and <-chan should wait for each other
+	*/
+	go func() {
+		ctrlCh <- *msmtReply
+	}()
+
+	return quicMsmt
+}
+
+func (quicMsmt *QuicThroughputMsmt) quicServerWorker(closeCh <-chan interface{}, goHeartbeatCh chan<- bool, port int, streamIndex int, msmtInfoPtr *shared.MsmtInfoObj, connPtr *shared.QuicConn) {
+	var listener quic.Listener
+	fTsExists := false
+	stream := "stream" + strconv.Itoa(streamIndex)
+	fmt.Printf("\n%s is here", stream)
+
+	tlsConf := create_tls_config()
+
+	for {
+		listen := quicMsmt.listenAddr + ":" + strconv.Itoa(port)
+
+		// TODO CHECK IF THAT WORKS AS WITH UDP AND TCP
+		listener, error := quic.ListenAddr(listen, tlsConf, nil)
+		if error == nil {
+			// debug fmt.Printf("\nCan listen on addr: %s\n", listen)
+			quicMsmt.usedPorts = append(quicMsmt.usedPorts, port)
+			connPtr.SrvSock = listener
+			goHeartbeatCh <- true
+			break
+		}
+
+		port++
+	}
+
+	sess, error := listener.Accept()
+	if error != nil {
+		fmt.Printf("Cannot accept: %s\n", error)
+		os.Exit(1)
+	}
+
+	// TODO CHECK IF THAT WORKS AS WITH UDP AND TCP
+	fmt.Printf("Connection from %s\n", sess.RemoteAddr())
+	connPtr.AcceptSock = sess
+
+	quicStream, err := sess.AcceptStream()
+	if err != nil {
+		panic("acceptStream")
+	}
+
+	message := make([]byte, quicMsmt.callSize, quicMsmt.callSize)
+
+	for {
+		bytes, err := io.ReadFull(quicStream, message)
+
+		// TODO CHECK IF ADVANCED ERROR HANDLING NECESSARY
+		if err != nil {
+			panic("readStream")
+		}
+
+		msmtInfoPtr.Bytes += uint64(bytes)
+
+		if fTsExists == false {
+			fTs := shared.ConvCurrDateToStr()
+			msmtInfoPtr.FirstTs = fTs
+			fTsExists = true
+		}
+
+		lTs := shared.ConvCurrDateToStr()
+		msmtInfoPtr.LastTs = lTs
+	}
+}
+
+func (quicMsmt *QuicThroughputMsmt) CloseConn() {
+	var mgmtData map[string]string
+	var msmtData []shared.DataResultObj
+	var combinedData shared.CombinedData
+
+	for c, quicConns := range quicMsmt.connStorage {
+		fmt.Println("\nClosing stream: ", c)
+		quicConns.AcceptSock.Close()
+		quicConns.SrvSock.Close()
+	}
+
+	msmtReply := new(shared.ChMsmt2Ctrl)
+	msmtReply.Status = "ok"
+
+	mgmtData = make(map[string]string)
+	mgmtData["msmtId"] = quicMsmt.msmtId
+	mgmtData["msg"] = "all modules closed"
+
+	combinedData.MgmtData = mgmtData
+
+	for c := 1; c <= quicMsmt.numStreams; c++ {
+		stream := "stream" + strconv.Itoa(c)
+
+		msmtStruct := quicMsmt.msmtInfoStorage[stream]
+
+		dataElement := new(shared.DataResultObj)
+		dataElement.Received_bytes = strconv.Itoa(int(msmtStruct.Bytes))
+		dataElement.Timestamp_first = msmtStruct.FirstTs
+		dataElement.Timestamp_last = msmtStruct.LastTs
+
+		msmtData = append(msmtData, *dataElement)
+		fmt.Println("\nmsmtData is: ", msmtData)
+	}
+
+	combinedData.MsmtData = msmtData
+	msmtReply.Data = combinedData
+
+	go func() {
+		quicMsmt.msmt2CtrlCh <- *msmtReply
+	}()
+}
+
+func (quicMsmt *QuicThroughputMsmt) GetMsmtInfo() {
+	var msmtData []shared.DataResultObj
+
+	msmtReply := new(shared.ChMsmt2Ctrl)
+	msmtReply.Status = "ok"
+
+	// prepare msmtReply.Data
+	for c := 1; c <= quicMsmt.numStreams; c++ {
+		stream := "stream" + strconv.Itoa(c)
+
+		msmtStruct := quicMsmt.msmtInfoStorage[stream]
+
+		dataElement := new(shared.DataResultObj)
+		dataElement.Received_bytes = strconv.Itoa(int(msmtStruct.Bytes))
+		dataElement.Timestamp_first = msmtStruct.FirstTs
+		dataElement.Timestamp_last = msmtStruct.LastTs
+
+		msmtData = append(msmtData, *dataElement)
+		fmt.Println("\nmsmtData is: ", msmtData)
+	}
+
+	msmtReply.Data = msmtData
+
+	go func() {
+		quicMsmt.msmt2CtrlCh <- *msmtReply
+	}()
+}
+
+// we could also move that to common-funcs => improvement
+func create_tls_config() *tls.Config {
+	// 1. generate KEY: generate 1024 bit key using RNG
+	pKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		panic("generateRsa")
+	}
+
+	// 2. x509 CERT template
+	certTemplate := x509.Certificate{SerialNumber: big.NewInt(1)}
+
+	// 3. create self-signed x509 certificate => DER used for binary encoded certs
+	certDER, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &pKey.PublicKey, pKey)
+	if err != nil {
+		panic("generateX509DER")
+	}
+
+	// 4. encode key in PEM
+	pKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(pKey)})
+
+	// 5. encode certDER in PEM
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	// 6. create tls cert
+	tlsCert, err := tls.X509KeyPair(certPEM, pKeyPEM)
+	if err != nil {
+		fmt.Println("generateTlsCert")
+	}
+
+	return &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+}

--- a/measurement-plane/quic-throughput/server.go
+++ b/measurement-plane/quic-throughput/server.go
@@ -1,0 +1,1 @@
+package quicThroughput

--- a/measurement-plane/tcp-throughput/server.go
+++ b/measurement-plane/tcp-throughput/server.go
@@ -3,6 +3,7 @@ package tcpThroughput
 import "fmt"
 import "os"
 import "net"
+import "io"
 import "strconv"
 import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
@@ -144,14 +145,17 @@ func (tcpMsmt *TcpMsmtObj) tcpServerWorker(closeCh <-chan interface{}, goHeartbe
 	message := make([]byte, tcpMsmt.callSize, tcpMsmt.callSize)
 
 	for {
-		bytes, error := conn.Read(message)
-		if error != nil {
-			if error.(*net.OpError).Err.Error() == "use of closed network connection" {
-				// debug fmt.Println("\nTCP Closed network detected! I am ignoring this")
+		bytes, err := conn.Read(message)
+		if err != nil {
+			if err == io.EOF {
 				break
 			}
 
-			fmt.Printf("TCP server worker! Cannot read: %s\n", error)
+			if err.(*net.OpError).Err.Error() == "use of closed network connection" {
+				break
+			}
+
+			// something different serious...
 			os.Exit(1)
 		}
 

--- a/measurement-plane/tcp-throughput/server.go
+++ b/measurement-plane/tcp-throughput/server.go
@@ -7,8 +7,6 @@ import "io"
 import "strconv"
 import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
-var UPDATE_INTERVAL = 5
-
 type TcpMsmtObj struct {
 	numStreams      int
 	usedPorts       []int

--- a/measurement-plane/tcp-throughput/server.go
+++ b/measurement-plane/tcp-throughput/server.go
@@ -159,7 +159,7 @@ func (tcpMsmt *TcpMsmtObj) tcpServerWorker(closeCh <-chan interface{}, goHeartbe
 			os.Exit(1)
 		}
 
-		msmtInfoPtr.Bytes = uint64(bytes)
+		msmtInfoPtr.Bytes += uint64(bytes)
 
 		if fTsExists == false {
 			fTs := shared.ConvCurrDateToStr()
@@ -189,7 +189,9 @@ func (tcpMsmt *TcpMsmtObj) CloseConn() {
 	msmtData["msg"] = "all modules closed"
 	msmtReply.Data = msmtData
 
-	// TODO: we have to attach the final Measurement Data
+	// TODO: Include the final measurement data => This will solve the "wrong" time duration calc
+	// PROBLEM: We must hand over a combination of strings AND array of results
+	// but we can only type cast to one of them?!
 	go func() {
 		tcpMsmt.msmt2CtrlCh <- *msmtReply
 	}()

--- a/measurement-plane/udp-throughput/client.go
+++ b/measurement-plane/udp-throughput/client.go
@@ -12,12 +12,10 @@ var DEF_BUFFER_SIZE = 8096 * 8
 func NewUdpMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.DataObj, wg *sync.WaitGroup, closeConnCh <-chan string) {
 	lAddr := config.Listen_addr
 
-	fmt.Println("\nUDP Destination listen addr: ", lAddr)
 	serverPorts := shared.ConvStrToIntSlice(msmtStartRep.Measurement.Configuration.UsedPorts)
 
 	for _, port := range serverPorts {
 		listen := lAddr + ":" + strconv.Itoa(port)
-		fmt.Println("\nCommunicating with: ", listen)
 		wg.Add(1)
 		go udpClientWorker(listen, wg, closeConnCh)
 	}
@@ -36,7 +34,6 @@ func udpClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string)
 			if cmd == "close" {
 				conn.Close()
 				wg.Done()
-				fmt.Println("\nClosing UDP connection")
 				return
 			} else {
 				fmt.Printf("\nudpClient worker did not understand cmd: %s", cmd)

--- a/measurement-plane/udp-throughput/server.go
+++ b/measurement-plane/udp-throughput/server.go
@@ -167,7 +167,9 @@ func (udpMsmt *UdpThroughputMsmt) udpServerWorker(closeCh <-chan interface{}, go
 }
 
 func (udpMsmt *UdpThroughputMsmt) CloseConn() {
-	var msmtData map[string]string
+	var mgmtData map[string]string
+	var msmtData []shared.DataResultObj
+	var combinedData shared.CombinedData
 
 	for streamId, conn := range udpMsmt.connStorage {
 		fmt.Println("\nUDP closing: ", streamId)
@@ -177,10 +179,27 @@ func (udpMsmt *UdpThroughputMsmt) CloseConn() {
 	msmtReply := new(shared.ChMsmt2Ctrl)
 	msmtReply.Status = "ok"
 
-	msmtData = make(map[string]string)
-	msmtData["msmtId"] = udpMsmt.msmtId
-	msmtData["msg"] = "all modules closed"
-	msmtReply.Data = msmtData
+	mgmtData = make(map[string]string)
+	mgmtData["msmtId"] = udpMsmt.msmtId
+	mgmtData["msg"] = "all modules closed"
+	combinedData.MgmtData = mgmtData
+
+	for c := 1; c <= udpMsmt.numStreams; c++ {
+		stream := "stream" + strconv.Itoa(c)
+
+		msmtStruct := udpMsmt.msmtInfoStorage[stream]
+
+		dataElement := new(shared.DataResultObj)
+		dataElement.Received_bytes = strconv.Itoa(int(msmtStruct.Bytes))
+		dataElement.Timestamp_first = msmtStruct.FirstTs
+		dataElement.Timestamp_last = msmtStruct.LastTs
+
+		msmtData = append(msmtData, *dataElement)
+		fmt.Println("\nmsmtData is: ", msmtData)
+	}
+
+	combinedData.MsmtData = msmtData
+	msmtReply.Data = combinedData
 
 	go func() {
 		udpMsmt.msmt2CtrlCh <- *msmtReply

--- a/measurement-plane/udp-throughput/server.go
+++ b/measurement-plane/udp-throughput/server.go
@@ -6,8 +6,6 @@ import "net"
 import "strconv"
 import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
-var UPDATE_INTERVAL = 5
-
 type UdpThroughputMsmt struct {
 	numStreams      int
 	usedPorts       []int

--- a/measurement-plane/udp-throughput/server.go
+++ b/measurement-plane/udp-throughput/server.go
@@ -153,7 +153,7 @@ func (udpMsmt *UdpThroughputMsmt) udpServerWorker(closeCh <-chan interface{}, go
 			cltAddrExists = true
 		}
 
-		msmtInfo.Bytes = uint64(bytes)
+		msmtInfo.Bytes += uint64(bytes)
 
 		if fTsExists == false {
 			fTs := shared.ConvCurrDateToStr()

--- a/scripts/evaluation.py
+++ b/scripts/evaluation.py
@@ -23,7 +23,7 @@ pp = pprint.PrettyPrinter(indent=4)
 
 # read from pipe (stdin) until end of program
 lines_json = sys.stdin.read()
-# debug print("json lines", lines_json)
+print("json lines", lines_json)
 
 # we got one lines of json, convert everyline
 # into our "db"

--- a/scripts/evaluation.py
+++ b/scripts/evaluation.py
@@ -22,6 +22,7 @@ pp = pprint.PrettyPrinter(indent=4)
 
 # read from pipe (stdin) until end of program
 lines_json = sys.stdin.read()
+print("json lines", lines_json)
 
 # we got one lines of json, convert everyline
 # into our "db"
@@ -74,7 +75,10 @@ for entry in db:
 
 measurement_length = (datetime_max - datetime_min).total_seconds()
 bytes_sec = bytes_rx / measurement_length
+Mbits_sec = (bytes_sec * 8) / 10**6
 print('overall bandwith: {} bytes/sec'.format(bytes_sec))
+print('overall bandwith: {} Mbits/sec'.format(Mbits_sec))
+
 print('measurement length: {} sec]'.format(measurement_length))
 print('received: {} bytes]'.format(bytes_rx))
 


### PR DESCRIPTION
what is fixed:
- mapago now outputs the correct bytes
- evaluation.py performs the right graph display
- naming of cli args 
- fixed bugs regarding loopback

what is tested:
- we can evaluate the mapago (tcp) performance
- its the same as with trxer
