### PR TITLE
Added & Tested: Byte-count for TCP-Throughput

### DIFF
--- a/control-plane/control-plane.go
+++ b/control-plane/control-plane.go
@@ -261,7 +261,7 @@ func supportedModules() map[string]string {
 	supportedMods["tcp-goodput"] = ""
 	supportedMods["quic-goodput"] = ""
 	supportedMods["tcp-tls-goodput"] = ""
-	
+
 	// TODO: Bring that up to data
 	return supportedMods
 }

--- a/mapago-client.go
+++ b/mapago-client.go
@@ -395,6 +395,8 @@ func sendQuicMsmtInfoRequest(addr string, port int, callSize int, currSrvBytes *
 	// debug fmt.Printf("\nmsmt stop request JSON is: % s", reqJson)
 
 	msmtInfoRep := tcpObj.GetMeasurementInfo(reqJson)
+	*currSrvBytes = countCurrSrvBytes(msmtInfoRep)
+
 	prepareOutput(msmtInfoRep)
 }
 

--- a/measurement-plane/quic-throughput/client.go
+++ b/measurement-plane/quic-throughput/client.go
@@ -21,6 +21,12 @@ func NewQuicMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.Data
 	// we need to ceil if the byte count per stream is uneven => or we cant reach the threshold
 	StreamBytes := uint(math.Ceil(float64(msmtTotalBytes) / float64(workers)))
 
+	/*
+	fmt.Println("\nTotal bytes: ", msmtTotalBytes)
+	fmt.Println("\nbytes per stream: ", StreamBytes)
+	fmt.Println("\ntotal bytes over all streams", StreamBytes * uint(workers))
+	*/ 
+
 	for i, port := range serverPorts {
 		listen := lAddr + ":" + strconv.Itoa(port)
 		stream := "stream" + strconv.Itoa(i+1)
@@ -88,7 +94,7 @@ func quicClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string
 				*sentStreamBytes = *sentStreamBytes + uint(bytes)
 
 				// case c): Default (streamBytes == 0 => enough sent) => Do nothing: Wait for channels
-			}
+			} 
 		}
 	}
 }

--- a/measurement-plane/quic-throughput/client.go
+++ b/measurement-plane/quic-throughput/client.go
@@ -5,21 +5,32 @@ import "os"
 import "strconv"
 import "fmt"
 import "crypto/tls"
+import "math"
 import quic "github.com/lucas-clemente/quic-go"
 import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
-func NewQuicMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.DataObj, wg *sync.WaitGroup, closeConnCh <-chan string, callSize int) {
+func NewQuicMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.DataObj, wg *sync.WaitGroup, closeConnCh <-chan string, callSize int, sentStreamBytes map[string]*uint, msmtTotalBytes uint) {
 	lAddr := config.Listen_addr
 	serverPorts := shared.ConvStrToIntSlice(msmtStartRep.Measurement.Configuration.UsedPorts)
+	workers, err := strconv.ParseUint(config.Worker, 10, 32)
+	if err != nil {
+		fmt.Printf("\n Parseuint error: %s", err)
+		os.Exit(1)
+	}
 
-	for _, port := range serverPorts {
+	// we need to ceil if the byte count per stream is uneven => or we cant reach the threshold
+	StreamBytes := uint(math.Ceil(float64(msmtTotalBytes) / float64(workers)))
+
+	for i, port := range serverPorts {
 		listen := lAddr + ":" + strconv.Itoa(port)
+		stream := "stream" + strconv.Itoa(i+1)
+
 		wg.Add(1)
-		go quicClientWorker(listen, wg, closeConnCh, callSize)
+		go quicClientWorker(listen, wg, closeConnCh, uint(callSize), sentStreamBytes[stream], StreamBytes)
 	}
 }
 
-func quicClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string, callSize int) {
+func quicClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string, callSize uint, sentStreamBytes *uint, streamBytes uint) {
 	buf := make([]byte, callSize, callSize)
 
 	tlsConf := tls.Config{InsecureSkipVerify: true}
@@ -42,15 +53,41 @@ func quicClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string
 				wg.Done()
 				return
 			} else {
-				fmt.Printf("\nTcpClient worker did not understand cmd: %s", cmd)
+				fmt.Printf("\nQuicClient worker did not understand cmd: %s", cmd)
 				os.Exit(1)
 			}
 		default:
-			// replace that with stream.Write(buf)
-			_, err := stream.Write(buf)
-			if err != nil {
-				fmt.Printf("\nWrite error: %s", err)
-				os.Exit(1)
+			// sent as long as "stream threshold" not reached
+			// case a) send whole callSize
+			if streamBytes >= callSize {
+				bytes, err := stream.Write(buf)
+
+				if err != nil {
+					fmt.Printf("\nWrite error: %s", err)
+					os.Exit(1)
+				}
+
+				// update per stream counter
+				streamBytes -= uint(bytes)
+				// update stream counter reference for mapago-client => determine when its done
+				*sentStreamBytes = *sentStreamBytes + uint(bytes)
+
+				// case b) last bytes to send are not a "full" buffer
+			} else if streamBytes < callSize && streamBytes > 0 {
+				buf = make([]byte, streamBytes, streamBytes)
+				bytes, err := stream.Write(buf)
+
+				if err != nil {
+					fmt.Printf("\nWrite error: %s", err)
+					os.Exit(1)
+				}
+
+				// update per stream counter
+				streamBytes -= uint(bytes)
+				// update stream counter reference for mapago-client => determine when its done
+				*sentStreamBytes = *sentStreamBytes + uint(bytes)
+
+				// case c): Default (streamBytes == 0 => enough sent) => Do nothing: Wait for channels
 			}
 		}
 	}

--- a/measurement-plane/quic-throughput/server.go
+++ b/measurement-plane/quic-throughput/server.go
@@ -152,8 +152,7 @@ func (quicMsmt *QuicThroughputMsmt) quicServerWorker(closeCh <-chan interface{},
 	message := make([]byte, quicMsmt.callSize, quicMsmt.callSize)
 
 	for {
-		bytes, err := io.ReadFull(quicStream, message)
-
+		bytes, err := quicStream.Read(message)
 		if err != nil {
 			if err == io.EOF {
 				break

--- a/measurement-plane/tcp-throughput/client.go
+++ b/measurement-plane/tcp-throughput/client.go
@@ -20,11 +20,9 @@ func NewTcpMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.DataO
 	// we need to ceil if the byte count per stream is uneven => or we cant reach the threshold
 	StreamBytes := uint(math.Ceil(float64(msmtTotalBytes) / float64(workers)))
 
-	/* debug
 	fmt.Println("\nTotal bytes: ", msmtTotalBytes)
 	fmt.Println("\nbytes per stream: ", StreamBytes)
 	fmt.Println("\ntotal bytes over all streams", StreamBytes * uint(workers))
-	*/
 
 	for i, port := range serverPorts {
 		listen := lAddr + ":" + strconv.Itoa(port)
@@ -89,6 +87,7 @@ func tcpClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string,
 
 				// case c): Default (streamBytes == 0 => enough sent) => Do nothing: Wait for channels
 			}
+
 		}
 	}
 }

--- a/measurement-plane/tcp-throughput/client.go
+++ b/measurement-plane/tcp-throughput/client.go
@@ -7,25 +7,28 @@ import "strconv"
 import "fmt"
 import "github.com/protocollabs/mapago/control-plane/ctrl/shared"
 
-func NewTcpMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.DataObj, wg *sync.WaitGroup, closeConnCh <-chan string, callSize int, msmtByteStore map[string]*uint) {
+func NewTcpMsmtClient(config shared.ConfigurationObj, msmtStartRep *shared.DataObj, wg *sync.WaitGroup, closeConnCh <-chan string, callSize int, sentStreamBytes map[string]*uint, msmtTotalBytes uint) {
 	lAddr := config.Listen_addr
 	serverPorts := shared.ConvStrToIntSlice(msmtStartRep.Measurement.Configuration.UsedPorts)
+	workers, err  := strconv.ParseUint(config.Worker, 10, 32)
+	if err != nil {
+		fmt.Printf("\n Parseuint error: %s", err)
+		os.Exit(1)
+	}
 
-	// debug fmt.Println("\nbyte store is ", msmtByteStore)
+	streamBytes := msmtTotalBytes / uint(workers) 
+	// debug fmt.Println("\nevery stream has to sent: ", streamBytes)
 
 	for i, port := range serverPorts {
 		listen := lAddr + ":" + strconv.Itoa(port)
 		stream := "stream" + strconv.Itoa(i + 1)
-		
-		// debug fmt.Println("\nstream is: ", stream)
-		// debug fmt.Println("\nvalue is: ", msmtByteStore[stream])
 
 		wg.Add(1)
-		go tcpClientWorker(listen, wg, closeConnCh, callSize, msmtByteStore[stream])
+		go tcpClientWorker(listen, wg, closeConnCh, uint(callSize), sentStreamBytes[stream], streamBytes)
 	}
 }
 
-func tcpClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string, callSize int, streamByteCtr *uint) {
+func tcpClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string, callSize uint, sentStreamBytes *uint, streamBytes uint) {
 	buf := make([]byte, callSize, callSize)
 	
 	// debug fmt.Println("\nbyte ctr is:", *streamByteCtr)
@@ -48,15 +51,38 @@ func tcpClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string,
 				os.Exit(1)
 			}
 		default:
+			// sent as long as "stream threshold" not reached
+			// case a) send whole callSize
+			if streamBytes >= callSize  {
+				bytes, err := conn.Write(buf)
+	
+				if err != nil {
+					fmt.Printf("\nWrite error: %s", err)
+					os.Exit(1)
+				}
 
-			bytes, err := conn.Write(buf)
-			if err != nil {
-				fmt.Printf("\nWrite error: %s", err)
-				os.Exit(1)
+				// update per stream counter
+				streamBytes -= uint(bytes)
+				// update stream counter reference for mapago-client => determine when its done
+				*sentStreamBytes = *sentStreamBytes + uint(bytes)
+			
+			// case b) last bytes to send are not a "full" buffer
+			} else if (streamBytes < callSize && streamBytes > 0) {
+				buf = make([]byte, streamBytes, streamBytes)
+				bytes, err := conn.Write(buf)
+	
+				if err != nil {
+					fmt.Printf("\nWrite error: %s", err)
+					os.Exit(1)
+				}
+
+				// update per stream counter
+				streamBytes -= uint(bytes)
+				// update stream counter reference for mapago-client => determine when its done
+				*sentStreamBytes = *sentStreamBytes + uint(bytes)
+
+			// case c): Default (streamBytes == 0 => enough sent) => Do nothing: Wait for channels
 			}
-
-			*streamByteCtr = *streamByteCtr + uint(bytes)
-
 		}
 	}
 }


### PR DESCRIPTION
- TCP-Worker now works on assigned "streamBytes"
- simplified TCP-Throughput handling
- function for checking if client has sent everything (doneSending)
- function for checking if MsmtInfoReplys change and if not => deadline
- TODO: invalidate data for test-sequencer if msmt failed