### PR TITLE
tcp: setup 20MB of read and write buffer

### DIFF
--- a/measurement-plane/tcp-throughput/client.go
+++ b/measurement-plane/tcp-throughput/client.go
@@ -38,8 +38,13 @@ func tcpClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string,
 	buf := make([]byte, callSize, callSize)
 
 	// debug fmt.Println("\nbyte ctr is:", *streamByteCtr)
+	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		fmt.Printf("Cannot resolve address: %s\n", addr)
+		return
+	}
 
-	conn, err := net.Dial("tcp", addr)
+	conn, err := net.DialTCP("tcp", nil, tcpAddr)
 	if err != nil {
 		errStr := strings.TrimSpace(err.Error())
 		if strings.Contains(errStr, "no route to host") {
@@ -50,6 +55,8 @@ func tcpClientWorker(addr string, wg *sync.WaitGroup, closeConnCh <-chan string,
 		fmt.Println("\nUnknown read error! exiting!")
 		os.Exit(1)
 	}
+	conn.SetWriteBuffer(20000000);
+	conn.SetReadBuffer(20000000);
 
 	for {
 		select {

--- a/measurement-plane/tcp-throughput/server.go
+++ b/measurement-plane/tcp-throughput/server.go
@@ -143,6 +143,8 @@ func (tcpMsmt *TcpMsmtObj) tcpServerWorker(closeCh <-chan interface{}, goHeartbe
 		fmt.Println("\nUnknown accept() error! exiting!")
 		os.Exit(1)
 	}
+	conn.SetWriteBuffer(20000000);
+	conn.SetReadBuffer(20000000);
 
 	fmt.Printf("Connection from %s\n", conn.RemoteAddr())
 	connPtr.AcceptSock = conn


### PR DESCRIPTION
This simple adds statically a read and write buffer size
of 20 MB for client and server connections.

The buffer size is not yet configurable.

Signed-off-by: Hagen Paul Pfeifer <hagen@jauu.net>